### PR TITLE
Allow MSpec choosing runner

### DIFF
--- a/Targets/RunMSpecSpecifications.target
+++ b/Targets/RunMSpecSpecifications.target
@@ -32,8 +32,9 @@
     
     <PropertyGroup>
       <MSpecOptions>--silent $(MSpecOutputType) "$(SpecificationReportPath)\Specs.html"</MSpecOptions>
+	  <MSpecRunner Condition="'$(MspecRunner)' == ''">mspec.exe</MSpecRunner>
       <MSpecArgs>$(MSpecSpecificationAssemblies)</MSpecArgs>
-      <MSpecCommand>"$(ReferencedAssembliesPath)\Machine.Specifications\mspec.exe" $(MSpecOptions) $(MSpecArgs)</MSpecCommand>
+      <MSpecCommand>"$(ReferencedAssembliesPath)\Machine.Specifications\$(MSpecRunner)" $(MSpecOptions) $(MSpecArgs)</MSpecCommand>
     </PropertyGroup>
     
     <Message Importance="high" Text="Running Specs with this command: $(MSpecCommand)"/>


### PR DESCRIPTION
Had to update to MSpec 0.4.7 which has different runner for .Net2 and .Net4 (mspec-clr4.exe)
