### PR TITLE
Add property to suppress TeamCity build number override

### DIFF
--- a/Properties/Build.properties
+++ b/Properties/Build.properties
@@ -29,6 +29,7 @@
     <HardLinksOptions Condition="'$(UseHardLinks)' == 'true'">
         CreateHardLinksForCopyAdditionalFilesIfPossible=$(UseHardLinks);CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=$(UseHardLinks);CreateHardLinksForCopyLocalIfPossible=$(UseHardLinks);CreateHardLinksForAdditionalFilesIfPossible=$(UseHardLinks);CreateHardLinksForPublishFilesIfPossible=$(UseHardLinks)
     </HardLinksOptions>
+    <OverrideTeamCityBuildNumber Condition="'$(DisplayBuildNumber)' != 'false'">true</OverrideTeamCityBuildNumber>
   </PropertyGroup>
 
   <!-- Versioning properties -->

--- a/Targets/UpdateAssemblyVersion.target
+++ b/Targets/UpdateAssemblyVersion.target
@@ -8,7 +8,7 @@
                   AssemblyInformationalVersion="$(SemanticVersion)"
                   AssemblyVersion="$(VersionMajor).$(VersionMinor).0.0" />
 				  	
-    <Message Text="##teamcity[buildNumber '$(SemanticVersion)']"  />
+    <Message Text="##teamcity[buildNumber '$(SemanticVersion)']" Condition="'$(OverrideTeamCityBuildNumber)' == 'true'" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Property: OverrideTeamCityBuildNumber (true by default).
Setting it to false will disable TempCity build number override in UpdateAssemblyVersion target.
